### PR TITLE
Pulled configuration information out into a standard config file in /etc...

### DIFF
--- a/obi/init.d/obiee
+++ b/obi/init.d/obiee
@@ -21,41 +21,10 @@
 # prompted for credentials when you start/stop them. 
 # Ref: http://docs.oracle.com/cd/E28280_01/web.1111/e13708/overview.htm#i1068920
 # ---------------------------------
-# These values must be adapted to your environment.
 
-# The OS owner under which OBIEE should be managed
-ORACLE_OWNR=oracle
+# Source config file
+. /etc/sysconfig/obiee
 
-# The FMW Home folder
-FMW_HOME=/home/oracle/obiee
-
-# Folder in which to store log files - change if you don't want them in /var/log
-LOG_PATH=/var/log
-
-# lsof path
-LSOF_PATH=/usr/sbin/lsof
-# 
-# 
-# 
-# -----------------
-# These should require no change.
-# -----------------
-BIEE_DOMAIN=bifoundation_domain    # Domain name
-BIEE_INSTANCE=instance1            # Instance name
-WLS_MANAGED_SERVER=bi_server1      # Server name
-WLS_PATH=$FMW_HOME/wlserver_10.3/server/bin
-WLS_DOMAIN_BIN=$FMW_HOME/user_projects/domains/$BIEE_DOMAIN/bin
-ORACLE_INSTANCE=$FMW_HOME/instances/$BIEE_INSTANCE
-#
-ADMIN_SERVER_START_TIMEOUT=300
-MANAGED_SERVER_START_TIMEOUT=600
-NODE_MANAGER_START_TIMEOUT=60
-OPMN_START_TIMEOUT=120
-ADMIN_SERVER_STOP_TIMEOUT=300
-MANAGED_SERVER_STOP_TIMEOUT=300
-NODE_MANAGER_STOP_TIMEOUT=60
-OPMN_STOP_TIMEOUT=120
-#
 export ORACLE_INSTANCE
 # --------------------------
 # Source function library.

--- a/obi/sysconfig/obiee
+++ b/obi/sysconfig/obiee
@@ -1,0 +1,27 @@
+# The OS owner under which OBIEE should be managed
+ORACLE_OWNR=oracle
+# The FMW Home folder
+FMW_HOME=/u01/app/oracle/product/obiee_1
+# Folder in which to store log files - change if you don't want them in /var/log
+LOG_PATH=/var/log
+# lsof path
+LSOF_PATH=/usr/sbin/lsof
+  
+# These typically require no change
+# -----------------
+BIEE_DOMAIN=bifoundation_domain    # Domain name
+BIEE_INSTANCE=instance1            # Instance name
+WLS_MANAGED_SERVER=bi_server1      # Server name
+WLS_PATH=$FMW_HOME/wlserver_10.3/server/bin
+WLS_DOMAIN_BIN=$FMW_HOME/user_projects/domains/$BIEE_DOMAIN/bin
+ORACLE_INSTANCE=$FMW_HOME/instances/$BIEE_INSTANCE
+
+# Timeouts
+ADMIN_SERVER_START_TIMEOUT=300
+MANAGED_SERVER_START_TIMEOUT=600
+NODE_MANAGER_START_TIMEOUT=60
+OPMN_START_TIMEOUT=120
+ADMIN_SERVER_STOP_TIMEOUT=300
+MANAGED_SERVER_STOP_TIMEOUT=300
+NODE_MANAGER_STOP_TIMEOUT=60
+OPMN_STOP_TIMEOUT=120


### PR DESCRIPTION
I pulled the parameters out of the main script and put them into a sysconfig file, which is a reasonably standard approach with init.d scripts. People are generally uneasy about making edits to scripts as opposed to config files.

I didn't spend to much time on comments, etc... I figured if you adopt this, then you can either make them yourself... or ask me to at that point.

It's one more file to manage... but it is pretty standard to do thi.
