### PR TITLE
set SUBSYS to init.d script name instead of rc?.d link name

### DIFF
--- a/obi/service/init.d/obiee
+++ b/obi/service/init.d/obiee
@@ -43,7 +43,7 @@ OBIS_FINGERPRINT=$FMW_HOME'.*/bin/opmn'
 # ---------------------------------
 
 # SUBSYS must match the script name (eg obiee), as it is used for the process lockfile
-SUBSYS=$(basename $0)
+SUBSYS=$(basename $(readlink -f $0))
 LOCK_FILE='/var/lock/subsys/'$SUBSYS
 START_LOG=$LOG_PATH/$SUBSYS-start.log
 STOP_LOG=$LOG_PATH/$SUBSYS-stop.log


### PR DESCRIPTION
Variable $SUBSYS used the scriptname from rc?.d directory e.g. 'S96obiee' instead of 'obiee' from init.d.

This prevents a OBIEE shutdown on runlevel 0 since the main rc script expects an lock file named after the init.d script.

Please notice: The log file names in /var/log will change too by this commit.
